### PR TITLE
Quick fix to install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,7 +25,7 @@ fi
 PAGE=$(echo $PAGE | sed -r 's:</Contents><Contents>:</Contents> <Contents>:g')
 
 fileprefx=""
-if [[ "$os" == "Darwin" ]]; then
+if [[ "$os" == "Darwin" ]] || [[ "$os" == "mac" ]]; then
   fileprefx="tmc-cli-rust-${platform}-apple-darwin-v"
 else
   fileprefx="tmc-cli-rust-${platform}-unknown-linux-gnu-v"


### PR DESCRIPTION
The install script incorrectly had only "Darwin" recognized as "mac" options (`uname -s` prints "Darwin"). For the lines mentioned in README to work, "mac" has to also work. 